### PR TITLE
Reverts to ubuntu-latest image

### DIFF
--- a/.github/workflows/tf-unit-tests.yml
+++ b/.github/workflows/tf-unit-tests.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
   terraform-unit-tests:
     name: "Terraform Unit Tests"
-    runs-on: [self-hosted, linux, x64, ]
+    runs-on: ubuntu-latest
 
     steps:
       # Checkout the repository to the GitHub Actions runner


### PR DESCRIPTION
Current unit test approach requires Docker, so switching back to the VM-based agents for now.