### PR TITLE
Update env var declaration in Dockerfile to resolve LegacyKeyValueFormat warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=deps /usr/src/app/node_modules ./node_modules
 FROM node:18-alpine AS runner
 WORKDIR /usr/src/app
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 RUN addgroup --gid 1001 --system nodejs
 RUN adduser --system twilio --uid 1001


### PR DESCRIPTION
Fixes #233

Update the `ENV` declaration in the `Dockerfile` to use the `key=value` format.

* Change `ENV NODE_ENV production` to `ENV NODE_ENV=production`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rodmhgl/twilio_apps/pull/234?shareId=904fa140-ab7e-4ef3-8123-21fe6ab034de).